### PR TITLE
Fixing a typo in file name

### DIFF
--- a/networking/super-netperf
+++ b/networking/super-netperf
@@ -38,7 +38,7 @@ process_netperf() {
       l=$(echo $l+rl | bc)
       tp=$(echo $tp+$t | bc)
       u=$(cat $file | grep "UNITS")
-      mv $file /tmp/old-$f
+      mv $file /tmp/old-$file
     done 
     echo "$top"
     echo "RT_LATENCY=$rtl"


### PR DESCRIPTION
k8s netperf is creating a file with old- in the client pod which is unexpected.
```
sh-5.1# cat old- 
MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 42424 AF_INET to 172.30.36.193 () port 42424 AF_INET : demo
RT_LATENCY=675.596
P99_LATENCY=781
THROUGHPUT=1480.18
THROUGHPUT_UNITS=Trans/s
[7:51](https://redhat-internal.slack.com/archives/D03TW30DXE2/p1680133881615079)
```
Suggesting mv $file /tmp/old-$file instead of mv $file /tmp/old-$f  in the script