### PR TITLE
Fixing type of mv command in super-netperf script

### DIFF
--- a/networking/super-netperf
+++ b/networking/super-netperf
@@ -38,7 +38,8 @@ process_netperf() {
       l=$(echo $l+rl | bc)
       tp=$(echo $tp+$t | bc)
       u=$(cat $file | grep "UNITS")
-      mv $file /tmp/old-$file
+      filename=$(basename $file)
+      mv $file /tmp/old-$filename
     done 
     echo "$top"
     echo "RT_LATENCY=$rtl"


### PR DESCRIPTION
Before
mv: cannot move `/tmp/result-1` to `/tmp/old-/tmp/result-1`: No such file or directory
After
Should be able to move `/tmp/result-1` to `/tmp/old-result-1`